### PR TITLE
BrickBench v0.3.4

### DIFF
--- a/resources/glsl/wiiobject.vert
+++ b/resources/glsl/wiiobject.vert
@@ -47,6 +47,7 @@ layout(set=7, binding=0) unwrap uniform HDRBlock{
 uniform int invertY;
 uniform vec3 billboardCenter;
 uniform vec2 billboardSize;
+uniform vec4 lightmapOffset;
 
 void pipeColorSet0(){
     vec3 gammaMeshColor = pow(color.rgb, vec3(gamma));
@@ -90,13 +91,14 @@ void main() {
 
     uv0 = vs_uv0;
     if(LIGHTMAP_UVSET == 0){
-        lightmapCoord = vs_uv0;
+        lightmapCoord = vs_uv0 * lightmapOffset.zw + lightmapOffset.xy;
     }else if(LIGHTMAP_UVSET == 1){
-        lightmapCoord = vs_uv1;
+        lightmapCoord = vs_uv1 * lightmapOffset.zw + lightmapOffset.xy;
+        //lightmapCoord = lightmapOffset.xy;
     }else if(LIGHTMAP_UVSET == 2){
-        lightmapCoord = vs_uv2;
+        lightmapCoord = vs_uv2 * lightmapOffset.zw + lightmapOffset.xy;
     }else{
-        lightmapCoord = vs_uv3;
+        lightmapCoord = vs_uv3 * lightmapOffset.zw + lightmapOffset.xy;
     }
 
     if(SURFACE_UVSET == 0){

--- a/src/com/opengg/loader/BrickBench.java
+++ b/src/com/opengg/loader/BrickBench.java
@@ -345,7 +345,6 @@ public class BrickBench extends GGApplication implements KeyboardListener, Mouse
                 } else if (s.equals("CLOSE")) {
                     exit();
                 } else if (s.equals("HOOK")) {
-                    //TCSHookManager.beginHook();
                 } else {
                     loadNewProject(Path.of(s));
                 }

--- a/src/com/opengg/loader/BrickBench.java
+++ b/src/com/opengg/loader/BrickBench.java
@@ -51,6 +51,7 @@ import com.opengg.core.world.WorldEngine;
 import com.opengg.core.world.components.Component;
 import com.opengg.core.world.components.LightComponent;
 import com.opengg.core.world.components.WorldObject;
+import com.opengg.loader.Project.GameVersion;
 import com.opengg.loader.components.*;
 import com.opengg.loader.editor.windows.SplashScreen;
 import com.opengg.loader.editor.*;
@@ -234,7 +235,6 @@ public class BrickBench extends GGApplication implements KeyboardListener, Mouse
             Map.entry("sensitivity", "0.5"),
             Map.entry("laf", "Flat Dark"),
             Map.entry("fov", "90"),
-            Map.entry("hook-executable-name", "LEGOStarWarsSaga.exe"),
             Map.entry("use-backup-lij-vao", "true"),
             Map.entry("autodelete-ai-pak", "true"),
             Map.entry("show-shadow-maps", "true"),
@@ -246,7 +246,9 @@ public class BrickBench extends GGApplication implements KeyboardListener, Mouse
             Map.entry("use-rotation-platform", "true"),
             Map.entry("show-lights", "true"),
             Map.entry("cache-textures", "true"),
-            Map.entry("enhanced-graphics", "true")
+            Map.entry("enhanced-graphics", "true"),
+            Map.entry(GameVersion.LSW_TCS.SHORT_NAME + "-hook-executable-name", GameVersion.LSW_TCS.EXECUTABLE),
+            Map.entry(GameVersion.LIJ1.SHORT_NAME + "-hook-executable-name", GameVersion.LIJ1.EXECUTABLE)
         );
 
         try {
@@ -343,7 +345,7 @@ public class BrickBench extends GGApplication implements KeyboardListener, Mouse
                 } else if (s.equals("CLOSE")) {
                     exit();
                 } else if (s.equals("HOOK")) {
-                    TCSHookManager.beginHook();
+                    //TCSHookManager.beginHook();
                 } else {
                     loadNewProject(Path.of(s));
                 }

--- a/src/com/opengg/loader/EditorEntity.java
+++ b/src/com/opengg/loader/EditorEntity.java
@@ -287,8 +287,10 @@ public interface EditorEntity<T extends EditorEntity<T>> {
         }
     }
 
-    record GroupProperty(String name, List<Property> value) implements Property{
-
+    record GroupProperty(String name, List<Property> value, boolean autoExpand) implements Property{
+        public GroupProperty(String name, List<Property> value){
+            this(name,value,false);
+        }
         @Override
         public String stringValue() {
             return value.stream().map(Property::stringValue).collect(Collectors.joining());

--- a/src/com/opengg/loader/Project.java
+++ b/src/com/opengg/loader/Project.java
@@ -36,7 +36,7 @@ public record Project(boolean isProject,
      * Therefore, the exactness of the game used in the current project only works in the context of a non-readonly project.
      */
     public enum GameVersion {
-        LIJ1(NU2, "lij1", "Lego Indiana Jones 1", "LEGOIndianaJones.exe"),
+        LIJ1(NU2, "lij1", "Lego Indiana Jones 1", "LEGOIndy.exe"),
         LB1(NU2, "lb1", "Lego Batman"),
         LSW_TCS(NU2, "lsw-tcs", "Lego Star Wars: The Complete Saga", "LEGOStarWarsSaga.exe"),
 

--- a/src/com/opengg/loader/Project.java
+++ b/src/com/opengg/loader/Project.java
@@ -36,9 +36,9 @@ public record Project(boolean isProject,
      * Therefore, the exactness of the game used in the current project only works in the context of a non-readonly project.
      */
     public enum GameVersion {
-        LIJ1(NU2, "lij1", "Lego Indiana Jones 1"),
+        LIJ1(NU2, "lij1", "Lego Indiana Jones 1", "LEGOIndianaJones.exe"),
         LB1(NU2, "lb1", "Lego Batman"),
-        LSW_TCS(NU2, "lsw-tcs", "Lego Star Wars: The Complete Saga"),
+        LSW_TCS(NU2, "lsw-tcs", "Lego Star Wars: The Complete Saga", "LEGOStarWarsSaga.exe"),
 
         LHP1_4(NXG, "lhp1-4", "Lego Harry Potter: Years 1-4"),
         LSW3(NXG, "lsw3", "Lego Star Wars 3: The Clone Wars");
@@ -55,7 +55,12 @@ public record Project(boolean isProject,
          * The user-readable name for this game.
          */
         public final String NAME;
-        GameVersion(EngineVersion engine, String shortName, String name) { ENGINE = engine; SHORT_NAME = shortName; NAME = name; };
+        /**
+         * The executable name for this game.
+         */
+        public final String EXECUTABLE;
+        GameVersion(EngineVersion engine, String shortName, String name) { this(engine, shortName, name, null); };
+        GameVersion(EngineVersion engine, String shortName, String name, String executable) { ENGINE = engine; SHORT_NAME = shortName; NAME = name; EXECUTABLE = executable; };
     }
 
     /**

--- a/src/com/opengg/loader/ProjectStructure.java
+++ b/src/com/opengg/loader/ProjectStructure.java
@@ -101,33 +101,20 @@ public record ProjectStructure(FolderNode root) {
             }
 
             case ProjectResource rn -> {
-                if (target.name().equals(rn.name())) {
-                    project.resources().remove(rn);
-                    yield true;
-                }
-                yield false;
+                yield target.name().equals(rn.name());
             }
 
             case MapXml fn -> {
-                if (target.name().equals(fn.name())) {
-                    project.maps().remove(fn);
-                    yield true;
-                }
-                yield false;
+                yield target.name().equals(fn.name());
             }
 
             case Area an -> {
                 if (target instanceof Area an2 && an.name().equals(an2.name())) {
-                    for (var map : an.maps()) {
-                        project.maps().remove(map);
-                    }
                     yield true;
-
                 } else {
                     for (int i = 0; i < an.maps().size(); i++) {
                         var map = an.maps().get(i);
                         if (map.name().equals(target.name())) {
-                            project.maps().remove(map);
                             an.maps().remove(map);
                         }
                     }

--- a/src/com/opengg/loader/components/NativeCache.java
+++ b/src/com/opengg/loader/components/NativeCache.java
@@ -5,8 +5,10 @@ import com.opengg.core.render.objects.ObjectCreator;
 
 public class NativeCache {
     public static Renderable CUBE;
+    public static Renderable CYLINDER;
 
     public static void initialize() {
         CUBE = ObjectCreator.createCube(1);
+        CYLINDER = ObjectCreator.createCylinder();
     }
 }

--- a/src/com/opengg/loader/components/TemporaryMeshComponent.java
+++ b/src/com/opengg/loader/components/TemporaryMeshComponent.java
@@ -36,6 +36,10 @@ public class TemporaryMeshComponent extends EditorEntityRenderComponent implemen
     }
 
     private void apply() {
+        if(!makeMesh && !makeTerrain){
+            SwingUtil.showLoadingAlert("Mesh Import","You must specify whether to apply this as a scene model, terrain, or both",true);
+            return;
+        }
         OpenGG.asyncExec(() -> {
             var matrix = Matrix4f.IDENTITY.translate(getPosition()).rotate(getRotation()).scale(getScale());
 
@@ -128,6 +132,6 @@ public class TemporaryMeshComponent extends EditorEntityRenderComponent implemen
                 new VectorProperty("Scale", getScale(), false, true),
                 new GroupProperty("Apply as", List.of(
                         new BooleanProperty("Terrain", makeTerrain, true),
-                        new BooleanProperty("Scene model", makeMesh, true))));
+                        new BooleanProperty("Scene model", makeMesh, true)),true));
     }
 }

--- a/src/com/opengg/loader/editor/hook/TCSHookManager.java
+++ b/src/com/opengg/loader/editor/hook/TCSHookManager.java
@@ -5,6 +5,7 @@ import com.opengg.core.math.Vector3f;
 import com.opengg.core.util.SystemUtil;
 import com.opengg.loader.BrickBench;
 import com.opengg.loader.SwingUtil;
+import com.opengg.loader.Project.GameVersion;
 import com.opengg.loader.components.HookCharacterManager;
 import com.opengg.loader.editor.EditorState;
 
@@ -28,13 +29,13 @@ public class TCSHookManager {
         return currentHook != null;
     }
 
-    public static void beginHook(){
+    public static void beginHook(GameExecutable executable){
         if (SystemUtil.IS_LINUX) {
             SwingUtil.showErrorAlert("This feature is currently not available on Linux");
             return;
         }
 
-        var hook = new TCSHookCommunicator();
+        var hook = new TCSHookCommunicator(executable);
         var success = hook.attemptHook();
 
         if (success) {
@@ -58,7 +59,7 @@ public class TCSHookManager {
     public static void update(){
         if (currentHook != null) {
             allCharacters.clear();
-            var active = panel.isLIJ() ? currentHook.checkForValidityAndReaquirePointersLIJ() : currentHook.checkForValidityAndReaquirePointers();
+            var active = currentHook.checkForValidityAndReaquirePointers();
             if (!active) {
                 currentHook.close();
                 currentHook = null;
@@ -69,7 +70,7 @@ public class TCSHookManager {
                 playerOne = new HookCharacter(currentHook.readPlayerLocation(1), 180 - currentHook.readPlayerAngle(1), 0);
                 playerTwo = new HookCharacter(currentHook.readPlayerLocation(2), 180 - currentHook.readPlayerAngle(2), 0);
 
-                allCharacters = panel.isLIJ() ? currentHook.getAllCharactersLIJ() : currentHook.getAllCharacters();
+                allCharacters = currentHook.getAllCharacters();
 
                 if (Configuration.getBoolean("autoload-hook")) {
                     var currentHookMap = currentHook.getCurrentMap();
@@ -89,5 +90,23 @@ public class TCSHookManager {
                 }
             }
         }
+    }
+    
+
+    public enum GameExecutable {
+        TCS_GOG(GameVersion.LSW_TCS, "gog", "GOG"),
+        TCS_STEAM(GameVersion.LSW_TCS, "steam", "Steam"),
+        LIJ1_GOG(GameVersion.LIJ1, "gog", "Steam");
+
+        public GameVersion GAME;
+        public String SHORT_NAME;
+        public String NAME;
+
+		private GameExecutable(GameVersion gAME, String shortName, String name) {
+			GAME = gAME;
+            SHORT_NAME = GAME.SHORT_NAME + "-" + shortName;
+            NAME = GAME.NAME + " (" + name + ")";
+
+		}
     }
 }

--- a/src/com/opengg/loader/editor/hook/TCSHookPanel.java
+++ b/src/com/opengg/loader/editor/hook/TCSHookPanel.java
@@ -42,22 +42,11 @@ public class TCSHookPanel extends JPanel implements EditorTab {
 
         JPanel hookManagerPanel = new JPanel(new WrapLayout());
 
-        JPopupMenu menu = new JPopupMenu();
-        JMenuItem header = new JMenuItem("<html><b>Select Game</b></html>");
-        header.setBackground(new JButton().getBackground());
-        header.setEnabled(false);
-        header.setOpaque(true);
-
-        for (var executable : GameExecutable.values()) {
-            var execItem = new JMenuItem(executable.NAME);
-            execItem.addActionListener(a -> TCSHookManager.beginHook(executable));
-            menu.add(execItem);
-        }
-
+        
         connectButton = new JButton("Start Hook");
         connectButton.addActionListener(a -> {
             if(!TCSHookManager.isEnabled()){
-                menu.show(connectButton, 0 , connectButton.getHeight());
+                generateGameSelectMenu(null).show(connectButton, 0 , connectButton.getHeight());
             }else{
                 TCSHookManager.endHook();
             }
@@ -184,6 +173,25 @@ public class TCSHookPanel extends JPanel implements EditorTab {
         tabPane.add("Options", configPanel);
         tabPane.add("AI Messages", aiMessagePanel);
         add(tabPane, BorderLayout.CENTER);
+    }
+
+    public static JPopupMenu generateGameSelectMenu(Runnable onSelect) {
+        JPopupMenu menu = new JPopupMenu();
+        JMenuItem header = new JMenuItem("<html><b>Select Game</b></html>");
+        header.setBackground(new JButton().getBackground());
+        header.setEnabled(false);
+        header.setOpaque(true);
+
+        for (var executable : GameExecutable.values()) {
+            var execItem = new JMenuItem(executable.NAME);
+            execItem.addActionListener(a -> {
+                TCSHookManager.beginHook(executable);
+                if (onSelect != null) onSelect.run();
+            });
+            menu.add(execItem);
+        }
+
+        return menu;
     }
 
     public void loadCurrentMap() {

--- a/src/com/opengg/loader/editor/tabs/EditorPane.java
+++ b/src/com/opengg/loader/editor/tabs/EditorPane.java
@@ -150,7 +150,7 @@ public class EditorPane extends JPanel implements EditorTab {
                         attachPropEditor(inner, innerProp, gameObject);
                     }
 
-                    EditorCollapsable collapsable = new EditorCollapsable(groupProp.name(), inner, false);
+                    EditorCollapsable collapsable = new EditorCollapsable(groupProp.name(), inner, groupProp.autoExpand());
                     collapsable.setAlignmentX(Component.LEFT_ALIGNMENT);
                     collapsable.setAlignmentY(Component.TOP_ALIGNMENT);
                     holder.add(collapsable);

--- a/src/com/opengg/loader/editor/tabs/ProjectStructurePanel.java
+++ b/src/com/opengg/loader/editor/tabs/ProjectStructurePanel.java
@@ -60,13 +60,14 @@ public class ProjectStructurePanel extends JPanel implements EditorTab {
                     OpenGG.asyncExec(() -> {
                         EditorState.getProject().structure().removeNode(EditorState.getProject(), pnuo.node());
 
-                        if (pnuo.node() instanceof MapXml) {
+                        if ((pnuo.node() instanceof MapXml map && EditorState.getActiveMap().levelData().xmlData() == map) ||
+                            (pnuo.node() instanceof Area area && area.maps().stream().anyMatch(map -> EditorState.getActiveMap().levelData().xmlData() == map))) {
                             if (EditorState.getProject().maps().isEmpty()) {
                                 BrickBench.CURRENT.useMapFromCurrentProject(null);
                             } else {
                                 BrickBench.CURRENT.useMapFromCurrentProject(EditorState.getProject().maps().get(0));
                             }
-                        }
+                        } 
 
                         EditorState.updateProject(EditorState.getProject());
                     });

--- a/src/com/opengg/loader/editor/windows/InitialProjectWindow.java
+++ b/src/com/opengg/loader/editor/windows/InitialProjectWindow.java
@@ -7,6 +7,7 @@ import com.opengg.core.engine.Resource;
 import com.opengg.loader.BrickBench;
 import com.opengg.loader.Util;
 import com.opengg.loader.editor.EditorIcons;
+import com.opengg.loader.editor.hook.TCSHookPanel;
 import net.miginfocom.swing.MigLayout;
 
 import javax.swing.*;
@@ -84,8 +85,10 @@ public class InitialProjectWindow extends JFrame {
         });
 
         openEmpty.addActionListener(a -> {
-            onOpSelect.accept("HOOK");
-            this.dispose();
+            TCSHookPanel.generateGameSelectMenu(() -> {
+                onOpSelect.accept("HOOK");
+                this.dispose();
+            }).show(openEmpty, 0 , openEmpty.getHeight());
         });
 
         var topRow = Box.createHorizontalBox();

--- a/src/com/opengg/loader/editor/windows/SettingsDialog.java
+++ b/src/com/opengg/loader/editor/windows/SettingsDialog.java
@@ -6,6 +6,7 @@ import com.opengg.core.Configuration;
 import com.opengg.core.console.GGConsole;
 import com.opengg.core.engine.Resource;
 import com.opengg.loader.FileUtil;
+import com.opengg.loader.Project.GameVersion;
 import com.opengg.loader.BrickBench;
 import com.opengg.loader.editor.EditorTheme;
 import com.opengg.loader.editor.components.FileSelectField;
@@ -20,6 +21,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.nio.file.Path;
+import java.util.Arrays;
 
 public class SettingsDialog extends JDialog {
 
@@ -212,10 +214,16 @@ public class SettingsDialog extends JDialog {
 
     private void useHookPanel(){
         resetPanel();
+        
+        Arrays.stream(GameVersion.values()).filter(v -> v.EXECUTABLE != null)
+            .forEach(v -> {
+                var hook = new JTextField(Configuration.get(v.SHORT_NAME + "-hook-executable-name"));
+                hook.addActionListener(a -> Configuration.getConfigFile("editor.ini").writeConfig(v.SHORT_NAME + "-hook-executable-name", hook.getText()));
+                hook.setToolTipText("Sets the " + v.SHORT_NAME.toUpperCase() + " executable name to hook into.");
+                
+                addItem(v.SHORT_NAME.toUpperCase() + " hook executable name", hook);
+            });
 
-        var hook = new JTextField(Configuration.get("hook-executable-name"));
-        hook.addActionListener(a -> Configuration.getConfigFile("editor.ini").writeConfig("hook-executable-name", hook.getText()));
-        hook.setToolTipText("Sets the TCS executable name to hook into.");
 
         var alphaOrderMaps = new JCheckBox();
         alphaOrderMaps.setSelected(Boolean.parseBoolean(Configuration.getConfigFile("editor.ini").getConfig("alphabetical-order-hook-map-list")));
@@ -224,7 +232,6 @@ public class SettingsDialog extends JDialog {
         alphaOrderMaps.setToolTipText("Sets if the list in the dropdown for maps in the hook should be in game order or alphabetical order.");
 
 
-        addItem("TCS hook executable name", hook);
         addCompactItem("Map list in alphabetical order", alphaOrderMaps);
 
         this.settingsPanel.validate();

--- a/src/com/opengg/loader/game/nu2/AreaIO.java
+++ b/src/com/opengg/loader/game/nu2/AreaIO.java
@@ -62,7 +62,7 @@ public class AreaIO {
             var mapDesiredPath = targetAreaDirectory.resolve(map.directory);
 
             var newName =  map.name.replaceAll("(?i)" + Pattern.quote(originalName), targetName);
-            if (project.maps().stream().anyMatch(m -> m.name().equalsIgnoreCase(newName))) {
+            if (project.maps().stream().anyMatch(m -> m.name().equalsIgnoreCase(newName))) { // Add old map to new area
                 var newMap = project.maps().stream().filter(m -> m.name().equalsIgnoreCase(newName)).findFirst().get();
                 var oldParent = project.structure().getParent(newMap);
 

--- a/src/com/opengg/loader/game/nu2/NU2MapComponent.java
+++ b/src/com/opengg/loader/game/nu2/NU2MapComponent.java
@@ -101,7 +101,7 @@ public class NU2MapComponent extends MapComponent<NU2MapData> {
 
         var parallax = mapData.getSpecialObjectByName("parallax");
         skybox.removeAll();
-        if(parallax.isPresent()){
+        if(parallax.isPresent() && mapData.txt().settingsMap().containsKey("farclip")){
             skybox.attach(new RenderComponent(new ParallaxComponent(parallax.get().model(),
                     mapData.txt().settingsMap().getOrDefault("farclip",1f)),
                     new SceneRenderUnit.UnitProperties().shaderPipeline("ttNormal")));

--- a/src/com/opengg/loader/game/nu2/NU2MapComponent.java
+++ b/src/com/opengg/loader/game/nu2/NU2MapComponent.java
@@ -99,12 +99,12 @@ public class NU2MapComponent extends MapComponent<NU2MapData> {
         specialObjects.removeAll();
         mapData.scene().specialObjects().forEach(specialObject -> specialObjects.attach(new SpecialObjectComponent(specialObject, mapData)));
 
-        var parallax = mapData.getSpecialObjectByName("parallax");
+        var parallax = mapData.getSpecialObjectByName("parallax").or(() -> mapData.getSpecialObjectByName("Parallax"));
         skybox.removeAll();
         if(parallax.isPresent() && mapData.txt().settingsMap().containsKey("farclip")){
             skybox.attach(new RenderComponent(new ParallaxComponent(parallax.get().model(),
                     mapData.txt().settingsMap().getOrDefault("farclip",1f)),
-                    new SceneRenderUnit.UnitProperties().shaderPipeline("ttNormal")));
+                    new SceneRenderUnit.UnitProperties().shaderPipeline("ttNormal").manualPriority(-3)));
         }
 
         updateTerrain();

--- a/src/com/opengg/loader/game/nu2/TxtLoader.java
+++ b/src/com/opengg/loader/game/nu2/TxtLoader.java
@@ -19,7 +19,7 @@ public class TxtLoader {
                 line = line.replaceAll("(//.*)", "").trim();
                 var tokens = line.split("[\s=]");
                 switch (tokens[0]){
-                    case "farclip" -> {
+                    case "farclip","farclip_pc"-> {
                         mapData.txt().settingsMap().put("farclip",Float.valueOf(tokens[1]));
                     }
                     case "door_start" -> {

--- a/src/com/opengg/loader/game/nu2/TxtLoader.java
+++ b/src/com/opengg/loader/game/nu2/TxtLoader.java
@@ -17,8 +17,11 @@ public class TxtLoader {
             while(scanner.hasNextLine()){
                 var line = scanner.nextLine();
                 line = line.replaceAll("(//.*)", "").trim();
-
-                switch (line.split("[\s=]")[0]){
+                var tokens = line.split("[\s=]");
+                switch (tokens[0]){
+                    case "farclip" -> {
+                        mapData.txt().settingsMap().put("farclip",Float.valueOf(tokens[1]));
+                    }
                     case "door_start" -> {
                         Spline doorSpline = null;
                         String targetMap = "Unknown";

--- a/src/com/opengg/loader/game/nu2/gizmo/GizmoManagerComponent.java
+++ b/src/com/opengg/loader/game/nu2/gizmo/GizmoManagerComponent.java
@@ -15,6 +15,7 @@ import com.opengg.core.world.components.Component;
 import com.opengg.loader.BrickBench;
 import com.opengg.loader.components.EditorEntityRenderComponent;
 import com.opengg.loader.components.BillBoardRenderable;
+import com.opengg.loader.components.NativeCache;
 
 import java.awt.*;
 import java.util.List;
@@ -167,7 +168,7 @@ public class GizmoManagerComponent extends Component {
         }else if(gizmo instanceof Gizmo.Tube gizTube){
             var renderable = new MatrixRenderable(
                 new TextureRenderable(
-                    ObjectCreator.createCylinder(), 
+                        NativeCache.CYLINDER,
                     Texture.ofColor(Color.PINK, 0.6f)),
                 new Matrix4f().scale(gizTube.radius(), gizTube.height(), gizTube.radius())
                     .translate(gizTube.pos().add(new Vector3f(0, gizTube.height(), 0))));

--- a/src/com/opengg/loader/game/nu2/scene/DisplayWriter.java
+++ b/src/com/opengg/loader/game/nu2/scene/DisplayWriter.java
@@ -118,7 +118,7 @@ public class DisplayWriter {
         var gscListEndAddr = scene.gscRenderableEndFromGSNH().get() +scene.blocks().get("GSNH").address() + 8;
         var gscListLen = scene.gscRenderableListLen().get();
 
-        SceneFileWriter.addSpace(gscListEndAddr, 4 * renderables.size());
+        SceneFileWriter.addSpace(gscListEndAddr, 4 * renderables.size()+4);
         EditorState.updateMap(MapLoader.reloadIndividualFile("gsc"));
 
         var pointerBuf = ByteBuffer.allocate(4 * renderables.size() + 4).order(ByteOrder.LITTLE_ENDIAN);

--- a/src/com/opengg/loader/game/nu2/scene/FileMaterial.java
+++ b/src/com/opengg/loader/game/nu2/scene/FileMaterial.java
@@ -648,7 +648,15 @@ public class FileMaterial implements DisplayCommandResource<FileMaterial> {
             case EditorEntityProperty mp && propName.equals("Diffuse texture") -> {
                 var texture = (FileTexture) mp.value();
                 MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0x74, Util.littleEndian((short) texture.descriptor().trueIndex()));
-                MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0xB4 + 0x4, Util.littleEndian((short) texture.descriptor().trueIndex()));
+                MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0xB4 + 0x4, Util.littleEndian((int) texture.descriptor().trueIndex()));
+            }
+            case EditorEntityProperty mp && propName.equals("Specular texture") -> {
+                var texture = (FileTexture) mp.value();
+                MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0xB4 + 0x48, Util.littleEndian((int) texture.descriptor().trueIndex()));
+            }
+            case EditorEntityProperty mp && propName.equals("Normal texture") -> {
+                var texture = (FileTexture) mp.value();
+                MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0xB4 + 0x4C, Util.littleEndian((int) texture.descriptor().trueIndex()));
             }
             case FloatProperty fp && propName.equals("Specular exponent") -> MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0xB4 + 0x7C, Util.littleEndian(fp.value()));
             case FloatProperty fp && propName.equals("Specular multiplier") -> MapWriter.applyPatch(MapWriter.WritableObject.SCENE, this.fileAddress + 0xB4 + 0x78, Util.littleEndian(fp.value()));

--- a/src/com/opengg/loader/game/nu2/scene/SceneFileLoader.java
+++ b/src/com/opengg/loader/game/nu2/scene/SceneFileLoader.java
@@ -94,6 +94,7 @@ public class SceneFileLoader {
             default -> new DefaultFileBlock();
         };
         block.readFromFile(fileBuffer, blockSize, blockId, fileBuffer.position(), mapData);
+        block.fileBuffer = null;
         fileBuffer.position(savePtr + blockSize);
 
         mapData.scene().blocks().put(blockName, new NU2MapData.SceneData.Block(savePtr, blockSize));

--- a/src/com/opengg/loader/game/nu2/scene/SceneFileLoader.java
+++ b/src/com/opengg/loader/game/nu2/scene/SceneFileLoader.java
@@ -15,6 +15,8 @@ import jdk.incubator.foreign.ResourceScope;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
 public class SceneFileLoader {
@@ -61,8 +63,16 @@ public class SceneFileLoader {
         fileBuffer.position(nu20Start + 0x20);
 
         while (fileBuffer.remaining() > 0) {
-            if(!loadBlockAtPosition(fileBuffer, mapData, false)) return;
+            if(!loadBlockAtPosition(fileBuffer, mapData, false)) break;
         }
+
+        //Re-sort because of out of order block loading
+        LinkedHashMap<String, NU2MapData.SceneData.Block> temp = new LinkedHashMap<>(mapData.scene().blocks());
+        mapData.scene().blocks().clear();
+        temp.entrySet()
+                .stream()
+                .sorted(Comparator.comparingInt(e -> e.getValue().address()))
+                .forEach((e1)->{mapData.scene().blocks().put(e1.getKey(),e1.getValue());});
     }
 
     private static boolean loadBlockAtPosition(ByteBuffer fileBuffer, NU2MapData mapData, boolean loadGameScene) throws IOException {

--- a/src/com/opengg/loader/game/nu2/scene/blocks/DisplaySetBlock.java
+++ b/src/com/opengg/loader/game/nu2/scene/blocks/DisplaySetBlock.java
@@ -104,8 +104,12 @@ public class DisplaySetBlock extends DefaultFileBlock {
                         int lm2 = fileBuffer.getInt();
                         int lm3 = fileBuffer.getInt();
                         int lm4 = fileBuffer.getInt();
+                        float xOffset = fileBuffer.getFloat();
+                        float yOffset = fileBuffer.getFloat();
+                        float zOffset = fileBuffer.getFloat();
+                        float wOffset = fileBuffer.getFloat();
 
-                        yield new LightmapCommandResource(resourcePtr, type == 2, lm, lm2, lm3, lm4, mapData);
+                        yield new LightmapCommandResource(resourcePtr, type, lm, lm2, lm3, lm4,xOffset,yOffset,zOffset,wOffset, mapData);
 
                     }
                     default -> {

--- a/src/com/opengg/loader/game/nu2/scene/commands/LightmapCommandResource.java
+++ b/src/com/opengg/loader/game/nu2/scene/commands/LightmapCommandResource.java
@@ -1,5 +1,6 @@
 package com.opengg.loader.game.nu2.scene.commands;
 
+import com.opengg.core.math.Vector4f;
 import com.opengg.core.render.shader.ShaderController;
 import com.opengg.loader.game.nu2.NU2MapData;
 import com.opengg.loader.game.nu2.scene.FileTexture;
@@ -11,16 +12,25 @@ public class LightmapCommandResource implements DisplayCommandResource<LightmapC
     private FileTexture texture2;
     private FileTexture texture3;
     private FileTexture texture4;
+    private float offsetX;
+    private float offsetY;
+    private float offsetZ;
+    private float offsetW;
 
     private int address;
+    private int lightmapType;
 
     private boolean multipleMaps = false;
-    public LightmapCommandResource(int address, boolean type, int id, int id2, int id3, int id4, NU2MapData mapData){
+    public LightmapCommandResource(int address, int lightmapType, int id, int id2, int id3, int id4,float offsetX,float offsetY, float offsetZ, float offsetW, NU2MapData mapData){
         texture = mapData.scene().texturesByRealIndex().get(id);
         texture2 = mapData.scene().texturesByRealIndex().get(id2);
         texture3 = mapData.scene().texturesByRealIndex().get(id3);
         texture4 = mapData.scene().texturesByRealIndex().get(id4);
-        multipleMaps = type;
+        this.offsetX = offsetX;
+        this.offsetY = offsetY;
+        this.offsetZ = offsetZ;
+        this.offsetW = offsetW;
+        this.lightmapType = lightmapType;
         this.address = address;
     }
 
@@ -31,11 +41,25 @@ public class LightmapCommandResource implements DisplayCommandResource<LightmapC
 
     @Override
     public void run() {
-        ShaderController.setUniform("lightmap1", texture.nativeTexture().getNow(null));
-        if(multipleMaps){
+        if(lightmapType == 2 || lightmapType == 4){
+            ShaderController.setUniform("lightmap1", texture.nativeTexture().getNow(null));
             ShaderController.setUniform("lightmap2", texture2.nativeTexture().getNow(null));
             ShaderController.setUniform("lightmap3", texture3.nativeTexture().getNow(null));
             ShaderController.setUniform("lightmap4", texture4.nativeTexture().getNow(null));
+            if(lightmapType == 4){
+                ShaderController.setUniform("lightmapOffset",new Vector4f(offsetX,offsetY,offsetZ,offsetW));
+            }else{
+                ShaderController.setUniform("lightmapOffset",new Vector4f(offsetX,offsetY,1,1));
+            }
+        }else if(lightmapType == 1 || lightmapType == 3){
+            ShaderController.setUniform("lightmap1", texture.nativeTexture().getNow(null));
+            if(lightmapType == 3){
+                ShaderController.setUniform("lightmapOffset",new Vector4f(offsetX,offsetY,offsetZ,offsetW));
+            }else{
+                ShaderController.setUniform("lightmapOffset",new Vector4f(offsetX,offsetY,1,1));
+            }
+        }else{
+            System.out.println("edge case");
         }
     }
 

--- a/src/com/opengg/loader/game/nu2/terrain/TerrainGroupComponent.java
+++ b/src/com/opengg/loader/game/nu2/terrain/TerrainGroupComponent.java
@@ -116,14 +116,17 @@ public class TerrainGroupComponent extends EditorEntityRenderComponent {
 
     @Override
     public void render(){
+        OpenGLRenderer.getOpenGLRenderer().setBackfaceCulling(true);
+        
         if(EditorState.CURRENT.shouldHighlight && EditorState.getSelectedObject().get() instanceof TerrainGroup obj && obj != this.terrainGroup) {
             ShaderController.setUniform("muteColors", 1);
         }else{
             ShaderController.setUniform("muteColors", 0);
         }
 
-        OpenGLRenderer.getOpenGLRenderer().setBackfaceCulling(false);
         super.render();
+
+        OpenGLRenderer.getOpenGLRenderer().setBackfaceCulling(false);
     }
 
     public TerrainGroup getTerrainGroup() {


### PR DESCRIPTION
Additions
* New UI for multigame hooks
* Made normal maps and specular maps editable

Changes
* Cylinders are now cached, improving memory usage
* New warning if user doesn't select import type when importing a model
* Many improvements to memory allocation
* Properly emulate lightmap UV scaling, greatly improving lighting in LIJ/Batman

Fixes
* Fix a render ordering issue when reloading files
* Fix off-by-one error resulting in GSC corruption when importing models
* Fix crash when removing maps
* Removing areas automatically closes any open maps in that area
* Fix to skybox render order